### PR TITLE
Fix bug where we were erroring out when trying to catch a program block with no videos

### DIFF
--- a/src/Program.js
+++ b/src/Program.js
@@ -192,28 +192,31 @@ class Program extends Component {
       return (
         <React.Fragment>
           { currentProgramBlock && currentProgramBlock.fields.videos &&
-            <React.Fragment>
-              <Video
-                video={currentProgramBlock.currentVideo}
-                timestamp={currentProgramBlock.timestampToStartVideo}
-              />
-              <VideoControls hasMultipleChannels={this.props.previousChannelSlug} maxMode={allowMaxMode && this.state.maxMode}>
-                { this.props.previousChannelSlug &&
-                    <ChannelButton direction="previous" to={this.props.previousChannelSlug} />
-                }
-
-                <div className={controlButtons}>
-                  <MuteButton />
-                </div>
-
-                { this.props.nextChannelSlug &&
-                    <ChannelButton direction="next" to={this.props.nextChannelSlug} />
-                }
-              </VideoControls>
-            </React.Fragment>
+            <Video
+              video={currentProgramBlock.currentVideo}
+              timestamp={currentProgramBlock.timestampToStartVideo}
+            />
           }
           { (!currentProgramBlock || !currentProgramBlock.fields.videos) &&
               <VideoPlaceholderWrapper />
+          }
+
+          { currentProgramBlock &&
+            <VideoControls hasMultipleChannels={this.props.previousChannelSlug} maxMode={allowMaxMode && this.state.maxMode}>
+              { this.props.previousChannelSlug &&
+                  <ChannelButton direction="previous" to={this.props.previousChannelSlug} />
+              }
+
+              { currentProgramBlock.fields.videos &&
+                <div className={controlButtons}>
+                  <MuteButton />
+                </div>
+              }
+
+              { this.props.nextChannelSlug &&
+                  <ChannelButton direction="next" to={this.props.nextChannelSlug} />
+              }
+            </VideoControls>
           }
         </React.Fragment>
       );

--- a/src/operations/programBlockOperations.js
+++ b/src/operations/programBlockOperations.js
@@ -50,6 +50,15 @@ const fetchProgramBlock = (programBlockId) => dispatch => {
 const initializeCurrentProgramBlockVideos = (currentProgramBlock) => dispatch => {
   consoleLog("- Initializing program block: ", currentProgramBlock.fields.title);
   return new Promise(function(resolve, reject) {
+    if (!currentProgramBlock.fields.videos) {
+      consoleLog("No videos in this program block!");
+      const loadedProgramBlock = {
+        sys: currentProgramBlock.sys,
+        fields: currentProgramBlock.fields
+      }
+      return dispatch(programBlockError(loadedProgramBlock, "Warning: This program block doesn't have any videos!"));
+    }
+
     // Doing this copy ish again, to prevent overwriting original info before we're ready,
     // and especially to prevent duplicate videos from not getting correct
     // indexes and start & end times
@@ -70,15 +79,6 @@ const initializeCurrentProgramBlockVideos = (currentProgramBlock) => dispatch =>
     let videoToPlayIndex = 0;
     let timestampToStartVideo = 0;
     let videosLength = videos.length;
-
-    if (!videos) {
-      consoleLog("No videos!");
-      const loadedProgramBlock = {
-        sys: currentProgramBlock.sys,
-        fields: currentProgramBlock.fields
-      }
-      return dispatch(programBlockError(loadedProgramBlock, "Warning: This program doesn't have any videos!"));
-    }
 
     // Set individual video lengths & full programming length
     videos.forEach((video, i) => {


### PR DESCRIPTION
Now, properly catch that there are no videos, and also correctly show  users the previous/next channel buttons, in the case the 'broken' program block is in a featured channel.